### PR TITLE
Added parameter to skip running NOTICE checks.

### DIFF
--- a/src/main/java/org/jasig/maven/notice/AbstractNoticeMojo.java
+++ b/src/main/java/org/jasig/maven/notice/AbstractNoticeMojo.java
@@ -63,7 +63,6 @@ import org.jasig.maven.notice.util.ResourceFinderImpl;
  * Common base mojo for notice related plugins
  * 
  * @author Eric Dalquist
- * @version $Revision$
  */
 public abstract class AbstractNoticeMojo extends AbstractMojo {
     
@@ -144,6 +143,13 @@ public abstract class AbstractNoticeMojo extends AbstractMojo {
     protected String[] licenseLookup = new String[0];
     
     /**
+     * Parameter to skip running checks entirely.
+     *
+     * @parameter expression="skip.checks"
+     */
+    private boolean skipChecks = false;
+    
+    /**
      * License Mapping XML files / URLs. Lookups are done in-order with
      * files being checked top to bottom for matches
      *
@@ -206,6 +212,7 @@ public abstract class AbstractNoticeMojo extends AbstractMojo {
      * @parameter default-value="  {0} under {1}"
      */
     protected String noticeMessage = "  {0} under {1}";
+    
     private MessageFormat parsedNoticeMessage;
     
     /**
@@ -223,6 +230,11 @@ public abstract class AbstractNoticeMojo extends AbstractMojo {
     public final void execute() throws MojoExecutionException, MojoFailureException {
         final Log logger = this.getLog();
         
+        if (this.skipChecks) {
+            logger.info("NOTICE file checks are skipped.");
+            return;
+        }
+        
         if (licenseLookup != null && licenseLookup.length > 0) {
             logger.warn("'licenseLookup' configuration property is deprecated use 'licenseMapping' instead");
             if (licenseMapping != null && licenseMapping.length > 0) {
@@ -230,7 +242,7 @@ public abstract class AbstractNoticeMojo extends AbstractMojo {
             }
             licenseMapping = licenseLookup;
         }
-
+       
         //Check if NOTICE for child modules should be generated
         if (!this.generateChildNotices && !this.project.isExecutionRoot()) {
             return;


### PR DESCRIPTION
In multi-module Maven projects, declaring the notice plugin at the root parent pom causes the plugin to be invoked every time for every module. This is specially annoying if NOTICE files are up to date and correct (checked manually by directly invoking the plugin from the command prompt) as there would be no need for a second verification. Additionally, the plugin attempts to repetitively check for modules that have already been validated.

If the multi-module build includes 3 modules of A, B, C, running the build with the plugin declared will validate NOTICE files for A, then A and B, then A and B and C. Obviously, not ideal. 

The validation process is particularly slow, and at times may cause out-of-memory issues specially during releasing of larger maven projects, such as CAS.
