### PR TITLE
Generate help mojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,20 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <configuration>
+                    <goalPrefix>notice</goalPrefix>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generated-helpmojo</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Add configuration for the maven-plugin-plugin so that a help mojo is generated at build time. Users can then invoke `mvn notice:help` to get a list of available plugin goals with descriptions.

Examples:
```
$ mvn notice:help

Maven NOTICE Generation Plugin
  Generates Apache style NOTICE files

This plugin has 3 goals:

notice:check
  Checks the NOTICE file to make sure it matches the expected output

notice:generate
  Generates the NOTICE file

notice:help
  Display help information on maven-notice-plugin.
  Call
    mvn notice:help -Ddetail=true -Dgoal=<goal-name>
  to display parameter details.
```

```
$ mvn notice:help -Ddetail=true

Maven NOTICE Generation Plugin
  Generates Apache style NOTICE files

This plugin has 3 goals:

notice:check
  Checks the NOTICE file to make sure it matches the expected output

  Available parameters:

    encoding (Default: ${project.build.sourceEncoding})
      (no description available)

    excludedModules
      ArtifactIds of child modules to exclude

    fileName (Default: NOTICE)
      Output file name

    generateChildNotices (Default: true)
      Set if a NOTICE file should be generated for each child module

    includeChildDependencies (Default: true)
      Set if the NOTICE file should include all dependencies from all child
      modules.

    licenseLookup
      Deprecated. use licenseMapping

      Use licenseMapping

    licenseMapping
      License Mapping XML files / URLs. Lookups are done in-order with files
      being checked top to bottom for matches

    noticeMessage (Default: {0} under {1})
      The MessageFormat syntax string used to generate each license line in the
      NOTICE file
      {0} - artifact name
      {1} - license name

    noticeTemplate (Default: NOTICE.template)
      Template for NOTICE file generation

    noticeTemplatePlaceholder (Default: #GENERATED_NOTICES#)
      Placeholder string in the NOTICE template file

    outputDir (Default: ${basedir})
      Output location for the generated NOTICE file

    skipChecks
      Parameter to skip running checks entirely.

notice:generate
  Generates the NOTICE file

  Available parameters:

    encoding (Default: ${project.build.sourceEncoding})
      (no description available)

    excludedModules
      ArtifactIds of child modules to exclude

    fileName (Default: NOTICE)
      Output file name

    generateChildNotices (Default: true)
      Set if a NOTICE file should be generated for each child module

    includeChildDependencies (Default: true)
      Set if the NOTICE file should include all dependencies from all child
      modules.

    licenseLookup
      Deprecated. use licenseMapping

      Use licenseMapping

    licenseMapping
      License Mapping XML files / URLs. Lookups are done in-order with files
      being checked top to bottom for matches

    noticeMessage (Default: {0} under {1})
      The MessageFormat syntax string used to generate each license line in the
      NOTICE file
      {0} - artifact name
      {1} - license name

    noticeTemplate (Default: NOTICE.template)
      Template for NOTICE file generation

    noticeTemplatePlaceholder (Default: #GENERATED_NOTICES#)
      Placeholder string in the NOTICE template file

    outputDir (Default: ${basedir})
      Output location for the generated NOTICE file

    skipChecks
      Parameter to skip running checks entirely.

notice:help
  Display help information on maven-notice-plugin.
  Call
    mvn notice:help -Ddetail=true -Dgoal=<goal-name>
  to display parameter details.

  Available parameters:

    detail (Default: false)
      If true, display all settable properties for each goal.

    goal
      The name of the goal for which to show help. If unspecified, all goals
      will be displayed.

    indentSize (Default: 2)
      The number of spaces per indentation level, should be positive.

    lineLength (Default: 80)
      The maximum length of a display line, should be positive.
```