### PR TITLE
Improve exception logging on license resolution failure

### DIFF
--- a/src/main/java/org/jasig/maven/notice/LicenseResolvingNodeVisitor.java
+++ b/src/main/java/org/jasig/maven/notice/LicenseResolvingNodeVisitor.java
@@ -165,7 +165,8 @@ class LicenseResolvingNodeVisitor implements DependencyNodeVisitor {
             return mavenProjectBuilder.buildFromRepository(artifact, remoteArtifactRepositories, localRepository, false);
         }
         catch (ProjectBuildingException e) {
-            this.logger.warn("Failed to find license info for: " + artifact);
+            this.logger.warn(String.format("Failed to find license info for: %s; cause: %s", artifact, e));
+            this.logger.debug(String.format("Failed to find license info for: %s", artifact), e);
         }
         return null;
     }

--- a/src/main/java/org/jasig/maven/notice/LicenseResolvingNodeVisitor.java
+++ b/src/main/java/org/jasig/maven/notice/LicenseResolvingNodeVisitor.java
@@ -165,7 +165,7 @@ class LicenseResolvingNodeVisitor implements DependencyNodeVisitor {
             return mavenProjectBuilder.buildFromRepository(artifact, remoteArtifactRepositories, localRepository, false);
         }
         catch (ProjectBuildingException e) {
-            this.logger.warn(String.format("Failed to find license info for: %s; cause: %s", artifact, e));
+            this.logger.warn(String.format("Failed to find license info for: %s; cause: %s", artifact, e.getMessage()));
             this.logger.debug(String.format("Failed to find license info for: %s", artifact), e);
         }
         return null;


### PR DESCRIPTION
Hi,

this is a very small patch that logs the exception if the resolution of a license for an artifact fails. In a recent case, such logged exception would have saved me some time so I thought it might be worse sharing!

Thanks and best regards
Matthes
