### PR TITLE
add <includeScopes> and <excludeScopes> configuration

### DIFF
--- a/src/main/java/org/jasig/maven/notice/ArtifactLicenseInfo.java
+++ b/src/main/java/org/jasig/maven/notice/ArtifactLicenseInfo.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.maven.notice;
+
+public class ArtifactLicenseInfo {
+
+    private final String artifactName;
+    private final String licenseName;
+    private final String scope;
+
+    public ArtifactLicenseInfo(String artifactName, String licenseName, String scope) {
+        this.artifactName = artifactName;
+        this.licenseName = licenseName;
+        this.scope = scope;
+    }
+
+    public String getArtifactName() {
+        return artifactName;
+    }
+
+    public String getLicenseName() {
+        return licenseName;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+}

--- a/src/main/java/org/jasig/maven/notice/LicenseResolvingNodeVisitor.java
+++ b/src/main/java/org/jasig/maven/notice/LicenseResolvingNodeVisitor.java
@@ -19,12 +19,11 @@
 
 package org.jasig.maven.notice;
 
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.TreeSet;
 
 import org.apache.commons.lang.StringUtils;
@@ -42,7 +41,11 @@ import org.apache.maven.shared.dependency.tree.traversal.DependencyNodeVisitor;
 import org.jasig.maven.notice.lookup.ArtifactLicense;
 
 class LicenseResolvingNodeVisitor implements DependencyNodeVisitor {
-    private final Map<String, String> resolvedLicenses = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+    private final Set<ArtifactLicenseInfo> resolvedLicenses = new TreeSet<ArtifactLicenseInfo>(new Comparator<ArtifactLicenseInfo>() {
+        public int compare(ArtifactLicenseInfo i1, ArtifactLicenseInfo i2) {
+            return String.CASE_INSENSITIVE_ORDER.compare(i1.getArtifactName(), i2.getArtifactName());
+        }
+    });
     private final Set<Artifact> unresolvedArtifacts = new TreeSet<Artifact>();
     private final Set<Artifact> visitedArtifacts = new HashSet<Artifact>();
     
@@ -65,7 +68,7 @@ class LicenseResolvingNodeVisitor implements DependencyNodeVisitor {
         this.localRepository = localRepository;
     }
     
-    public Map<String, String> getResolvedLicenses() {
+    public Set<ArtifactLicenseInfo> getResolvedLicenses() {
         return resolvedLicenses;
     }
 
@@ -146,7 +149,7 @@ class LicenseResolvingNodeVisitor implements DependencyNodeVisitor {
                 this.unresolvedArtifacts.add(artifact);
             }
             else {
-                this.resolvedLicenses.put(name, licenseName);
+                this.resolvedLicenses.add(new ArtifactLicenseInfo(name, licenseName, node.getArtifact().getScope()));
             }
         }
         return true;


### PR DESCRIPTION
The official Apache licensing howto says: "Dependencies which are not included in the distribution MUST NOT be added to LICENSE and NOTICE". Therefore, I think it would be nice to be able to exclude test dependencies, because they are usually not bundled with a distribution.

This PR adds an configuration option like this:

```
<configuration>
    <includeScopes>
        <includeScopes>compile</includeScopes>
    </includeScopes>
</configuration>
```

You can either specify `<includeScopes>` to list only the scopes you want to have included in the NOTICE file, or `<excludeScopes>` to list the scopes to be omitted from the NOTICE file.

See here for the quote above: http://www.apache.org/dev/licensing-howto.html#bundled-vs-non-bundled