### PR TITLE
build(mvn): disable doclint

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,19 +17,19 @@ under the License.
 
 This project includes:
   Apache Commons Collections under Apache License, Version 2.0
+  Apache Commons IO under Apache License, Version 2.0
   Backport of JSR 166 under Public Domain
   classworlds under BSD Style License
   CLI under Apache License, Version 2.0
-  Code Generation Library under ASF 2.0
-  Commons IO under The Apache Software License, Version 2.0
   Commons Lang under The Apache Software License, Version 2.0
   Default Plexus Container under Apache License, Version 2.0
   Doxia Core under Apache License, Version 2.0
   EasyMock under Apache 2
+  Hamcrest Core under New BSD License
   java-diff-utils under The Apache Software License, Version 2.0
   JAXB2 Basics - Runtime under BSD-Style License
   jsch under BSD
-  JUnit under Common Public License Version 1.0
+  JUnit under Eclipse Public License 1.0
   Maven under The Apache Software License, Version 2.0
   Maven Artifact under The Apache Software License, Version 2.0
   Maven Artifact Manager under The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 
     <properties>
         <project-site-path>/maven-notice-plugin/${project.version}</project-site-path>
+        <additionalparam>-Xdoclint:none</additionalparam>
 
         <mavenVersion>2.2.1</mavenVersion>
         <jaxbApiVersion>2.2.1</jaxbApiVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <project-site-path>/maven-notice-plugin/${project.version}</project-site-path>
 
-        <mavenVersion>2.2.0</mavenVersion>
+        <mavenVersion>2.2.1</mavenVersion>
         <jaxbApiVersion>2.2.1</jaxbApiVersion>
         <jaxbImplVersion>2.2.1.1</jaxbImplVersion>
         <jaxbXjcVersion>2.2.1</jaxbXjcVersion>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.3</version>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
@@ -132,13 +132,13 @@
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>3.1</version>
+            <version>3.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file 
-    distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under 
-    the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may 
-    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to 
-    in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF 
-    ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under 
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under
+    the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may
+    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to
+    in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+    ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
     the License. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -31,7 +31,7 @@
     <prerequisites>
         <maven>2.2.1</maven>
     </prerequisites>
-    
+
     <scm>
         <connection>scm:git:git://github.com/Jasig/maven-notice-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:Jasig/maven-notice-plugin.git</developerConnection>
@@ -40,7 +40,7 @@
 
     <properties>
         <project-site-path>/maven-notice-plugin/${project.version}</project-site-path>
-        
+
         <mavenVersion>2.2.0</mavenVersion>
         <jaxbApiVersion>2.2.1</jaxbApiVersion>
         <jaxbImplVersion>2.2.1.1</jaxbImplVersion>
@@ -80,7 +80,7 @@
             <artifactId>maven-dependency-tree</artifactId>
             <version>1.2</version>
         </dependency>
-        
+
 
         <!-- Maven Provided -->
         <dependency>
@@ -121,7 +121,7 @@
             <version>1.5.5</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <!-- Test -->
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>


### PR DESCRIPTION
Needed to ignore generated files that block release on Java 8.

Also updates doc headers, library versions, and notice file.