### PR TITLE
Update version to 1.1-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/vim,java,linux,macos,maven,emacs,eclipse,windows,netbeans,sublimetext,intellij+all
+
+# intellij project files
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,12 @@
     <parent>
         <groupId>org.jasig.parent</groupId>
         <artifactId>jasig-parent</artifactId>
-        <version>33</version>
+        <version>41</version>
     </parent>
 
     <groupId>org.jasig.maven</groupId>
     <artifactId>maven-notice-plugin</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Maven NOTICE Generation Plugin</name>
@@ -45,7 +45,7 @@
         <jaxbApiVersion>2.2.1</jaxbApiVersion>
         <jaxbImplVersion>2.2.1.1</jaxbImplVersion>
         <jaxbXjcVersion>2.2.1</jaxbXjcVersion>
-        <jaxb2basicsVersion>0.6.3</jaxb2basicsVersion>
+        <jaxb2basicsVersion>1.11.1</jaxb2basicsVersion>
     </properties>
 
     <dependencies>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.3</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
-            <version>1.2</version>
+            <version>2.2</version>
         </dependency>
         
 
@@ -126,19 +126,19 @@
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>3.1</version>
+            <version>3.5.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -153,11 +153,16 @@
                         <noticeTemplate>NOTICE.template</noticeTemplate>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-plugin-plugin</artifactId>
+                    <version>2.9</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
               <artifactId>maven-enforcer-plugin</artifactId>
+              <version>1.4.1</version>
               <executions>
                 <execution>
                   <goals><goal>enforce</goal></goals>
@@ -175,27 +180,24 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0.2</version>
+                <version>2.5.1</version>
                 <configuration>
                     <source>1.5</source>
                     <target>1.5</target>
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-plugin-plugin</artifactId>
-                <version>2.6</version>
-            </plugin>
-            <plugin>
                 <artifactId>maven-site-plugin</artifactId>
+                <version>2.4</version>
                 <configuration>
                     <reportPlugins>
                         <plugin>
                             <artifactId>maven-project-info-reports-plugin</artifactId>
-                            <version>2.2</version>
+                            <version>2.9</version>
                         </plugin>
                         <plugin>
                             <artifactId>maven-plugin-plugin</artifactId>
-                            <version>2.6</version>
+                            <version>2.9</version>
                             <configuration>
                                 <requirements>
                                     <jdk>1.5</jdk>
@@ -205,21 +207,21 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-surefire-report-plugin</artifactId>
-                            <version>2.6</version>
+                            <version>2.20.1</version>
                         </plugin>
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-jxr-plugin</artifactId>
-                            <version>2.2</version>
+                            <version>2.5</version>
                         </plugin>
                         <plugin>
                             <groupId>org.codehaus.mojo</groupId>
                             <artifactId>cobertura-maven-plugin</artifactId>
-                            <version>2.4</version>
+                            <version>2.7</version>
                         </plugin>
                         <plugin>
                             <artifactId>maven-pmd-plugin</artifactId>
-                            <version>2.5</version>
+                            <version>2.7.1</version>
                             <configuration>
                                 <linkXref>true</linkXref>
                                 <sourceEncoding>utf-8</sourceEncoding>
@@ -230,7 +232,7 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-changelog-plugin</artifactId>
-                            <version>2.2</version>
+                            <version>2.3</version>
                         </plugin>
                         <plugin>
                             <groupId>org.codehaus.mojo</groupId>
@@ -240,12 +242,12 @@
                         <plugin>
                             <groupId>org.codehaus.mojo</groupId>
                             <artifactId>findbugs-maven-plugin</artifactId>
-                            <version>2.3.1</version>
+                            <version>2.5.5</version>
                         </plugin>
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-javadoc-plugin</artifactId>
-                            <version>2.7</version>
+                            <version>2.10.4</version>
                             <configuration>
                                 <source>1.5</source>
                                 <maxmemory>512m</maxmemory>
@@ -261,7 +263,7 @@
                         <plugin>
                             <groupId>org.codehaus.mojo</groupId>
                             <artifactId>jdepend-maven-plugin</artifactId>
-                            <version>2.0-beta-2</version>
+                            <version>2.0</version>
                         </plugin>
                     </reportPlugins>
                 </configuration>
@@ -269,6 +271,7 @@
             <plugin>
                 <groupId>com.mycila.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>
+                <version>1.10.b1</version>
                 <configuration>
                     <excludes>
                         <exclude>NOTICE</exclude>
@@ -284,7 +287,7 @@
             <plugin>
                 <groupId>org.jvnet.jaxb2.maven2</groupId>
                 <artifactId>maven-jaxb2-plugin</artifactId>
-                <version>0.7.4</version>
+                <version>0.7.5</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.googlecode.java-diff-utils</groupId>
             <artifactId>diffutils</artifactId>
-            <version>1.2.1</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/src/main/java/org/jasig/maven/notice/AbstractNoticeMojo.java
+++ b/src/main/java/org/jasig/maven/notice/AbstractNoticeMojo.java
@@ -219,7 +219,7 @@ public abstract class AbstractNoticeMojo extends AbstractMojo {
      * {0} - artifact name<br>
      * {1} - license name<br>
      *
-     * @parameter default-value=" {0} under {1}"
+     * @parameter default-value="  {0} under {1}"
      */
     protected String noticeMessage = "  {0} under {1}";
 

--- a/src/main/java/org/jasig/maven/notice/CheckNoticeMojo.java
+++ b/src/main/java/org/jasig/maven/notice/CheckNoticeMojo.java
@@ -103,11 +103,11 @@ public class CheckNoticeMojo extends AbstractNoticeMojo {
             Log logger, Reader noticeContents, Reader existingNoticeContents) {
         final StringBuilder diffText = new StringBuilder();
         try {
-            final List<?> expectedLines = IOUtils.readLines(noticeContents);
-            final List<?> existingLines = IOUtils.readLines(existingNoticeContents);
-            final Patch diff = DiffUtils.diff(expectedLines, existingLines);
+            final List<String> expectedLines = IOUtils.readLines(noticeContents);
+            final List<String> existingLines = IOUtils.readLines(existingNoticeContents);
+            final Patch<String> diff = DiffUtils.diff(expectedLines, existingLines);
 
-            for (final Delta delta : diff.getDeltas()) {
+            for (final Delta<String> delta : diff.getDeltas()) {
                 final Chunk original = delta.getOriginal();
                 final Chunk revised = delta.getRevised();
 


### PR DESCRIPTION
Update to latest parent version and various dependencies

NOTE: this project still depends on Maven 2 and java 1.5. Moving to Maven 3 should be done on a major version bump